### PR TITLE
Show coverart in tencent backend

### DIFF
--- a/backendModules/tencentGuess.js
+++ b/backendModules/tencentGuess.js
@@ -5,13 +5,13 @@ export async function tencentGuess(audio) {
 
     return {
         title: response.songlist[0].songname,
-        artist: response.songlist[0].singername,
-        year: response.songlist[0].albumname,
+        artist: response.songlist[0]?.singername,
+        year: response.songlist[0]?.albumname,
         apple: "",
         deezer: "",
         spotify: "",
         youtube: "",
-        art: ""
+        art: `https://y.gtimg.cn/music/photo_new/T002R300x300M000${response.songlist[0]?.albummid}.jpg`
     }
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds album art URL to the Tencent guess response and uses optional chaining for artist/year fields.
> 
> - **Backend** (`backendModules/tencentGuess.js`):
>   - **Result payload**:
>     - Add `art` URL using `response.songlist[0]?.albummid`.
>     - Use optional chaining for `artist` and `year` (`response.songlist[0]?.singername`, `?.albumname`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65719adc437e916fc5863eb0bcaa4dc0c5fba5b8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->