### PR TITLE
Add missing translations for settings import and export

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -408,6 +408,36 @@
   "captureMethodTabCapture": {
     "message": "chrome.tabCapture",
     "description": "Tab capture method option"
+  },
+  "settingsExportFailed": {
+    "message": "Export fehlgeschlagen: ",
+    "description": "Message shown when settings export failed"
+  },
+  "importedBackupFileFormatIsInvalid": {
+    "message": "Ungültiges Dateiformat. Bitte wählen Sie eine Librezam-Sicherungsdatei aus.",
+    "description": "Error message for invalid backup file format"
+  },
+  "confirmOverwritingSettings": {
+    "message": "Dadurch werden Ihre aktuellen Einstellungen und Ihr Verlauf überschrieben.\nWeitermachen?\n\nDatum der Backup-Erstellung: $1\nAnzahl der Verlaufseinträge: $2 Elemente",
+    "description": "Confirm overwriting the settings and history",
+    "placeholders": {
+      "date": {
+        "content": "$1",
+        "example": "2026-03-28T16:23:29.976Z"
+      },
+      "histories": {
+        "content": "$2",
+        "example": "45"
+      }
+    }
+  },
+  "settingsImportCompleted": {
+    "message": "Einstellungen importiert! Bitte aktualisieren Sie die Seite.",
+    "description": "Message shown when settings import is completed"
+  },
+  "settingsImportFailed": {
+    "message": "Import fehlgeschlagen: ",
+    "description": "Message shown when settings import failed"
   }
 }
 

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -408,5 +408,35 @@
   "captureMethodTabCapture": {
     "message": "chrome.tabCapture",
     "description": "Tab capture method option"
+  },
+  "settingsExportFailed": {
+    "message": "Export failed: ",
+    "description": "Message shown when settings export failed"
+  },
+  "importedBackupFileFormatIsInvalid": {
+    "message": "Invalid file format. Please select a Librezam backup file.",
+    "description": "Error message for invalid backup file format"
+  },
+  "confirmOverwritingSettings": {
+    "message": "This will overwrite your current settings and history.\nContinue?\n\nBackup creation date: $1\nNumber of history entries: $2 items",
+    "description": "Confirm overwriting the settings and history",
+    "placeholders": {
+      "date": {
+        "content": "$1",
+        "example": "2026-03-28T16:23:29.976Z"
+      },
+      "histories": {
+        "content": "$2",
+        "example": "45"
+      }
+    }
+  },
+  "settingsImportCompleted": {
+    "message": "Settings imported! Please refresh the page.",
+    "description": "Message shown when settings import is completed"
+  },
+  "settingsImportFailed": {
+    "message": "Import failed: ",
+    "description": "Message shown when settings import failed"
   }
 }

--- a/_locales/es/messages.json
+++ b/_locales/es/messages.json
@@ -408,6 +408,36 @@
   "captureMethodTabCapture": {
     "message": "chrome.tabCapture",
     "description": "Tab capture method option"
+  },
+  "settingsExportFailed": {
+    "message": "Exportación fallida: ",
+    "description": "Message shown when settings export failed"
+  },
+  "importedBackupFileFormatIsInvalid": {
+    "message": "Formato de archivo no válido. Seleccione una copia de seguridad de Librezam.",
+    "description": "Error message for invalid backup file format"
+  },
+  "confirmOverwritingSettings": {
+    "message": "Esto sobrescribirá su configuración e historial actuales.\n¿Continuar?\n\nFecha de creación de la copia de seguridad: $1\nEntradas del historial: $2 elementos",
+    "description": "Confirm overwriting the settings and history",
+    "placeholders": {
+      "date": {
+        "content": "$1",
+        "example": "2026-03-28T16:23:29.976Z"
+      },
+      "histories": {
+        "content": "$2",
+        "example": "45"
+      }
+    }
+  },
+  "settingsImportCompleted": {
+    "message": "¡Configuración importada! Por favor, actualiza la página.",
+    "description": "Message shown when settings import is completed"
+  },
+  "settingsImportFailed": {
+    "message": "Falló la importación: ",
+    "description": "Message shown when settings import failed"
   }
 }
 

--- a/_locales/fr/messages.json
+++ b/_locales/fr/messages.json
@@ -408,6 +408,36 @@
   "captureMethodTabCapture": {
     "message": "chrome.tabCapture",
     "description": "Tab capture method option"
+  },
+  "settingsExportFailed": {
+    "message": "Échec de l'exportation : ",
+    "description": "Message shown when settings export failed"
+  },
+  "importedBackupFileFormatIsInvalid": {
+    "message": "Format de fichier invalide. Veuillez sélectionner un fichier de sauvegarde Librezam.",
+    "description": "Error message for invalid backup file format"
+  },
+  "confirmOverwritingSettings": {
+    "message": "Ceci écrasera vos paramètres et votre historique actuels.\nContinuer ?\n\nDate de création de la sauvegarde : $1\nNombre d'entrées dans l'historique : $2 éléments",
+    "description": "Confirm overwriting the settings and history",
+    "placeholders": {
+      "date": {
+        "content": "$1",
+        "example": "2026-03-28T16:23:29.976Z"
+      },
+      "histories": {
+        "content": "$2",
+        "example": "45"
+      }
+    }
+  },
+  "settingsImportCompleted": {
+    "message": "Paramètres importés ! Veuillez rafraîchir la page.",
+    "description": "Message shown when settings import is completed"
+  },
+  "settingsImportFailed": {
+    "message": "Échec de l'importation : ",
+    "description": "Message shown when settings import failed"
   }
 }
 

--- a/_locales/it/messages.json
+++ b/_locales/it/messages.json
@@ -408,6 +408,36 @@
   "captureMethodTabCapture": {
     "message": "chrome.tabCapture",
     "description": "Tab capture method option"
+  },
+  "settingsExportFailed": {
+    "message": "Esportazione non riuscita: ",
+    "description": "Message shown when settings export failed"
+  },
+  "importedBackupFileFormatIsInvalid": {
+    "message": "Formato file non valido. Seleziona un file di backup Librezam.",
+    "description": "Error message for invalid backup file format"
+  },
+  "confirmOverwritingSettings": {
+    "message": "Le impostazioni e la cronologia attuali verranno sovrascritte.\nContinuare?\n\nData di creazione del backup: $1\nNumero di voci nella cronologia: $2 elementi",
+    "description": "Confirm overwriting the settings and history",
+    "placeholders": {
+      "date": {
+        "content": "$1",
+        "example": "2026-03-28T16:23:29.976Z"
+      },
+      "histories": {
+        "content": "$2",
+        "example": "45"
+      }
+    }
+  },
+  "settingsImportCompleted": {
+    "message": "Impostazioni importate! Aggiorna la pagina.",
+    "description": "Message shown when settings import is completed"
+  },
+  "settingsImportFailed": {
+    "message": "Importazione non riuscita: ",
+    "description": "Message shown when settings import failed"
   }
 }
 

--- a/_locales/ja/messages.json
+++ b/_locales/ja/messages.json
@@ -408,5 +408,35 @@
   "captureMethodTabCapture": {
     "message": "chrome.tabCapture",
     "description": "Tab capture method option"
+  },
+  "settingsExportFailed": {
+    "message": "エクスポートに失敗しました: ",
+    "description": "Message shown when settings export failed"
+  },
+  "importedBackupFileFormatIsInvalid": {
+    "message": "無効なファイル形式です。Librezamのバックアップファイルを選択してください。",
+    "description": "Error message for invalid backup file format"
+  },
+  "confirmOverwritingSettings": {
+    "message": "この操作は現在の設定と履歴を上書きします。\n続行しますか？\n\nバックアップ作成日: $1\n履歴数: $2件",
+    "description": "Confirm overwriting the settings and history",
+    "placeholders": {
+      "date": {
+        "content": "$1",
+        "example": "2026-03-28T16:23:29.976Z"
+      },
+      "histories": {
+        "content": "$2",
+        "example": "45"
+      }
+    }
+  },
+  "settingsImportCompleted": {
+    "message": "インポートが完了しました。ページを再読み込みしてください。",
+    "description": "Message shown when settings import is completed"
+  },
+  "settingsImportFailed": {
+    "message": "インポートに失敗しました: ",
+    "description": "Message shown when settings import failed"
   }
 }

--- a/_locales/ko/messages.json
+++ b/_locales/ko/messages.json
@@ -408,6 +408,36 @@
   "captureMethodTabCapture": {
     "message": "chrome.tabCapture",
     "description": "Tab capture method option"
+  },
+  "settingsExportFailed": {
+    "message": "설정 내보내기 실패: ",
+    "description": "Message shown when settings export failed"
+  },
+  "importedBackupFileFormatIsInvalid": {
+    "message": "잘못된 파일 형식입니다. Librezam 백업 파일을 선택하십시오.",
+    "description": "Error message for invalid backup file format"
+  },
+  "confirmOverwritingSettings": {
+    "message": "이렇게 하면 현재 설정과 기록이 덮어쓰여집니다.\n계속하다?\n\n백업 생성 날짜: $1\n이력 항목 수: $2개",
+    "description": "Confirm overwriting the settings and history",
+    "placeholders": {
+      "date": {
+        "content": "$1",
+        "example": "2026-03-28T16:23:29.976Z"
+      },
+      "histories": {
+        "content": "$2",
+        "example": "45"
+      }
+    }
+  },
+  "settingsImportCompleted": {
+    "message": "설정이 불러와졌습니다! 페이지를 새로고침해 주세요.",
+    "description": "Message shown when settings import is completed"
+  },
+  "settingsImportFailed": {
+    "message": "설정 가져오기 실패: ",
+    "description": "Message shown when settings import failed"
   }
 }
 

--- a/_locales/ru/messages.json
+++ b/_locales/ru/messages.json
@@ -408,6 +408,36 @@
   "captureMethodTabCapture": {
     "message": "chrome.tabCapture",
     "description": "Tab capture method option"
+  },
+  "settingsExportFailed": {
+    "message": "Ошибка экспорта: ",
+    "description": "Message shown when settings export failed"
+  },
+  "importedBackupFileFormatIsInvalid": {
+    "message": "Неверный формат файла. Пожалуйста, выберите файл резервной копии Librezam.",
+    "description": "Error message for invalid backup file format"
+  },
+  "confirmOverwritingSettings": {
+    "message": "Это перезапишет ваши текущие параметры и историю.\nПродолжить?\n\nДата создания резервной копии: $1\nКоличество записей в истории: $2 элемента",
+    "description": "Confirm overwriting the settings and history",
+    "placeholders": {
+      "date": {
+        "content": "$1",
+        "example": "2026-03-28T16:23:29.976Z"
+      },
+      "histories": {
+        "content": "$2",
+        "example": "45"
+      }
+    }
+  },
+  "settingsImportCompleted": {
+    "message": "Настройки импортированы! Пожалуйста, обновите страницу.",
+    "description": "Message shown when settings import is completed"
+  },
+  "settingsImportFailed": {
+    "message": "Ошибка импорт: ",
+    "description": "Message shown when settings import failed"
   }
 }
 

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -408,6 +408,36 @@
   "captureMethodTabCapture": {
     "message": "chrome.tabCapture",
     "description": "Tab capture method option"
+  },
+  "settingsExportFailed": {
+    "message": "导出失败: ",
+    "description": "Message shown when settings export failed"
+  },
+  "importedBackupFileFormatIsInvalid": {
+    "message": "文件格式无效。请选择一个Librezam备份文件。",
+    "description": "Error message for invalid backup file format"
+  },
+  "confirmOverwritingSettings": {
+    "message": "这将覆盖您当前的设置和历史记录。\n继续？\n\n备份创建日期: $1\n历史记录条目数：$2 项",
+    "description": "Confirm overwriting the settings and history",
+    "placeholders": {
+      "date": {
+        "content": "$1",
+        "example": "2026-03-28T16:23:29.976Z"
+      },
+      "histories": {
+        "content": "$2",
+        "example": "45"
+      }
+    }
+  },
+  "settingsImportCompleted": {
+    "message": "设置已导入！请刷新页面。",
+    "description": "Message shown when settings import is completed"
+  },
+  "settingsImportFailed": {
+    "message": "导入失败: ",
+    "description": "Message shown when settings import failed"
   }
 }
 

--- a/_locales/zh_TW/messages.json
+++ b/_locales/zh_TW/messages.json
@@ -408,6 +408,36 @@
   "captureMethodTabCapture": {
     "message": "chrome.tabCapture",
     "description": "Tab capture method option"
+  },
+  "settingsExportFailed": {
+    "message": "匯出設定失敗: ",
+    "description": "Message shown when settings export failed"
+  },
+  "importedBackupFileFormatIsInvalid": {
+    "message": "文件格式無效。請選擇一個Librezam備份檔。",
+    "description": "Error message for invalid backup file format"
+  },
+  "confirmOverwritingSettings": {
+    "message": "這將覆蓋您目前的設定和歷史記錄。\n繼續？\n\n備份建立日期: $1\n歷史記錄條目數量：$2 條",
+    "description": "Confirm overwriting the settings and history",
+    "placeholders": {
+      "date": {
+        "content": "$1",
+        "example": "2026-03-28T16:23:29.976Z"
+      },
+      "histories": {
+        "content": "$2",
+        "example": "45"
+      }
+    }
+  },
+  "settingsImportCompleted": {
+    "message": "設定已導入！請刷新頁面。",
+    "description": "Message shown when settings import is completed"
+  },
+  "settingsImportFailed": {
+    "message": "導入失敗: ",
+    "description": "Message shown when settings import failed"
   }
 }
 

--- a/popup/historySettings.js
+++ b/popup/historySettings.js
@@ -1,4 +1,5 @@
 import { getStorage, setStorage, Defaults } from "../common/storageHelper.js"
+import { t } from "./i18n.js"
 
 // Clear History
 M.Modal.init(modalConfirmClear, null);
@@ -49,7 +50,7 @@ exportAllData.addEventListener("click", async () => {
         URL.revokeObjectURL(url)
     } catch (error) {
         console.error("Export failed:", error)
-        alert("エクスポートに失敗しました: " + error.message)
+        alert(t('settingsExportFailed') + error.message)
     }
 });
 
@@ -69,16 +70,14 @@ importAllData.addEventListener("click", () => {
             
             // Validate metadata
             if (!data._metadata || !data._metadata.version) {
-                throw new Error("無効なファイル形式です。Librezamのバックアップファイルを選択してください。")
+                throw new Error(t('importedBackupFileFormatIsInvalid'))
             }
             
             // Confirm import
-            const confirmed = confirm(
-                "この操作は現在の設定と履歴を上書きします。\n" +
-                "続行しますか？\n\n" +
-                `バックアップ作成日: ${data._metadata.exportDate}\n` +
-                `履歴数: ${data.histories ? data.histories.length : 0}件`
-            )
+            const confirmed = confirm(t('confirmOverwritingSettings', [
+                data._metadata.exportDate,
+                data.histories ? data.histories.length : 0,
+            ]))
             
             if (!confirmed) return
             
@@ -89,11 +88,11 @@ importAllData.addEventListener("click", () => {
                 }
             }
             
-            alert("インポートが完了しました。ページを再読み込みしてください。")
+            alert(t('settingsImportCompleted'))
             
         } catch (error) {
             console.error("Import failed:", error)
-            alert("インポートに失敗しました: " + error.message)
+            alert(t('settingsImportFailed') + error.message)
         }
     })
     


### PR DESCRIPTION
While importing Librezam settings from another browser I got messages in Japanese and noticed they were hard coded and missing translations.

I added i18n to `historySettings.js` and created new keys in every localization JSON files.

Translations could probably be improved as I'm only fluent in French and English and had to rely on online translation for the other languages.