### PR TITLE
Add setting to disable keyboard shortcuts

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -263,6 +263,10 @@
     "message": "Record another tab audio",
     "description": "Record another tab audio checkbox"
   },
+  "enableShortcuts": {
+    "message": "Enable keyboard shortcuts",
+    "description": "Enable keyboard shortcuts checkbox"
+  },
   "theme": {
     "message": "Theme",
     "description": "Theme section title"

--- a/background/background.js
+++ b/background/background.js
@@ -17,6 +17,8 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
 })
 
 chrome.commands?.onCommand.addListener(async (command) => {
+    if(!await getStorage("enableShortcuts")) return
+
     if(command == "tab-recognize"){
         await chrome.action.openPopup()
     }

--- a/common/storageHelper.js
+++ b/common/storageHelper.js
@@ -17,7 +17,8 @@ export const Defaults = {
     corsHosts: ["radio.garden"],
     sk: "da36b574-e869-41f5-8512-bc261615b84e",
     language: "auto",
-    captureMethod: "tabCapture"
+    captureMethod: "tabCapture",
+    enableShortcuts: true
 }
 
 export async function getStorage(key) {

--- a/popup/miscSettings.html
+++ b/popup/miscSettings.html
@@ -22,6 +22,12 @@
                     <span data-i18n="recordAnotherTabAudio">Record another tab audio</span>
                 </label>
             </p>
+            <p>
+                <label>
+                    <input id="enableShortcuts" type="checkbox" class="filled-in"/>
+                    <span data-i18n="enableShortcuts">Enable keyboard shortcuts</span>
+                </label>
+            </p>
             <p id="captureMethodContainer" style="display: none;">
                 <label for="captureMethodSelect" data-i18n="captureMethod">Recording Method</label>
                 <select id="captureMethodSelect" class="browser-default">

--- a/popup/miscSettings.js
+++ b/popup/miscSettings.js
@@ -6,6 +6,11 @@ isRecordAnotherTab.addEventListener("change", () => {
     setStorage("isRecordAnotherTab", isRecordAnotherTab.checked)
 })
 
+enableShortcuts.checked = await getStorage("enableShortcuts")
+enableShortcuts.addEventListener("change", () => {
+    setStorage("enableShortcuts", enableShortcuts.checked)
+})
+
 // Capture Method setting
 const captureMethodSelect = document.getElementById("captureMethodSelect")
 const captureMethodContainer = document.getElementById("captureMethodContainer")


### PR DESCRIPTION
On AltGr layouts (French...), Ctrl+Alt+E types an accented character, but the extension's shortcut swallows it, so the accent can't be typed anywhere while the extension is enabled
Adds an "Enable keyboard shortcuts" checkbox under Miscellaneous -> Options, on by default. When off, `chrome.commands.onCommand` returns early and the key combination passes through to the page.